### PR TITLE
corrected handling of BCE leap year calculation

### DIFF
--- a/decimaldate.py
+++ b/decimaldate.py
@@ -120,5 +120,11 @@ def _daysinyear(yearstring):
 
 def _isleapyear(yearstring):
     yearnumber = int(yearstring)
+
+    # handle BCE; there is no 0 so leap years are -1, -5, -9, ..., -2001, -2005, ...
+    # just add 1 to the year to correct for this, for this purpose
+    if yearnumber < 1:
+        yearnumber += 1
+
     isleap = yearnumber % 4 == 0 and (yearnumber % 100 != 0 or yearnumber % 400 == 0)
     return isleap

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,18 @@
 import decimaldate
 
+print("Test: Leap Year")
+
+assert decimaldate._isleapyear(400) is True
+assert decimaldate._isleapyear(1000) is False
+assert decimaldate._isleapyear(2000) is True
+assert decimaldate._isleapyear(1984) is True
+assert decimaldate._isleapyear(387) is False
+assert decimaldate._isleapyear(-401) is True
+assert decimaldate._isleapyear(-1001) is False
+assert decimaldate._isleapyear(-2001) is True
+assert decimaldate._isleapyear(-1985) is True
+assert decimaldate._isleapyear(-388) is False
+
 print("Test: ISO to Decimal, CE")
 
 decver = decimaldate.iso2dec('2000-01-01')


### PR DESCRIPTION
Corrects the handling of leap year calculation, when year is <0 (BCE)

There is no year 0 so leap years are -1, -5, -9, ... -2001, -2005, ... Basically add 1 to the integer value, or subtract 1 from the absolute value, but then follow all the usual rules.